### PR TITLE
Fixed order of operations

### DIFF
--- a/src/main/java/com/atherys/core/db/CachedHibernateRepository.java
+++ b/src/main/java/com/atherys/core/db/CachedHibernateRepository.java
@@ -37,26 +37,26 @@ public class CachedHibernateRepository<T extends Identifiable<ID>, ID extends Se
 
     @Override
     public void saveOne(T entity) {
-        cache.add(entity);
         super.saveOne(entity);
+        cache.add(entity);
     }
 
     @Override
     public void saveAll(Collection<T> entities) {
-        cache.addAll(entities);
         super.saveAll(entities);
+        cache.addAll(entities);
     }
 
     @Override
     public void deleteOne(T entity) {
-        cache.remove(entity);
         super.deleteOne(entity);
+        cache.remove(entity);
     }
 
     @Override
     public void deleteAll(Collection<T> entities) {
-        cache.removeAll(entities);
         super.deleteAll(entities);
+        cache.removeAll(entities);
     }
 
     @Override


### PR DESCRIPTION
SimpleCache requires an ID to be present, IDs are generated by the database. 
So we need to save the entity and then add it to the cache.